### PR TITLE
Update jquery.ntm.js

### DIFF
--- a/js/jquery.ntm.js
+++ b/js/jquery.ntm.js
@@ -53,10 +53,10 @@
                     }
                 }
 
-                if (parent.hasClass(options.selectedClass)) {
-                    //Thinesh - Explicitly hide the code that children nodes are expanded automatically next refresh.
+                //Thinesh - Explicitly hide the code that children nodes are expanded automatically next refresh.
+                //if (parent.hasClass(options.selectedClass)) {
                     //parent.removeClass(options.activeClass).removeClass(options.collapseClass).addClass(options.expandClass);
-                }
+                //}
             });
 
             $('.' + options.collapseClass + ' > ul', this).hide();


### PR DESCRIPTION
Explicitly hide the code that children nodes are expanded when parent selected automatically in next refresh.
